### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Cimbios/CimBios.Core/security/code-scanning/1](https://github.com/Cimbios/CimBios.Core/security/code-scanning/1)

To fix the problem, we should explicitly add a `permissions` block limiting the scope of permissions granted to the workflow's `GITHUB_TOKEN`. The industry-standard minimal starting point for build/test workflows is to grant only `contents: read`, preventing the workflow from write-accessing repository resources (such as source code, issues, PRs, etc.). This block should be added at the root of the workflow file, above the `jobs:` key, ensuring it applies globally unless overridden by per-job `permissions` scopes. No additional imports or modifications are required; only insertion of the appropriate `permissions` YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
